### PR TITLE
Rename overlay to Gnome19

### DIFF
--- a/overlay.xml
+++ b/overlay.xml
@@ -2,11 +2,11 @@
 <layman>
   <overlay
       type = "git"
-      src  = "git://github.com/CMoH/gnome15-overlay.git"
-      contact = "cheepeero@gmx.net"
+      src  = "git://github.com/nikopas/gnome15-overlay.git"
+      contact = "ni3pas@gmail.com"
       status = "unofficial"
-      name = "gnome15">
-    <link>http://github.com/CMoH/gnome15-overlay</link>
+      name = "gnome19">
+    <link>http://github.com/nikopas/gnome15-overlay</link>
     <description>Gentoo ebuilds for Gnome15 packages</description>
   </overlay>
 </layman>


### PR DESCRIPTION
Rename the overlay to Gnome19 in order to be able to use it in parallel with Gnome15.